### PR TITLE
Cache should be customer dependant

### DIFF
--- a/ps_bestsellers.php
+++ b/ps_bestsellers.php
@@ -260,4 +260,13 @@ class Ps_BestSellers extends Module implements WidgetInterface
 
         return $products_for_template;
     }
+    
+    protected function getCacheId($name = null)
+    {
+        $cacheId = parent::getCacheId($name);
+        if(!empty($this->context->customer->id)){
+            $cacheId .= '|' . (int) $this->context->customer->id;
+        }
+        return $cacheId;
+    }
 }


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | There are several issues in native modules because module cache is not customer dependant.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes #17111
| How to test?      | Add a customer dependent product price, load home page. Authenticate to another user of the same group : the price should be different.
| Possible impacts? | The cache will grow up.
