### PR TITLE
Remove "All best sellers" link if needed

### DIFF
--- a/ps_bestsellers.php
+++ b/ps_bestsellers.php
@@ -200,6 +200,7 @@ class Ps_BestSellers extends Module implements WidgetInterface
         if (!empty($products)) {
             return [
                 'products' => $products,
+                'displayBestSellers' => (bool) Configuration::get('PS_DISPLAY_BEST_SELLERS'),
                 'allBestSellers' => Context::getContext()->link->getPageLink('best-sales'),
             ];
         }

--- a/views/templates/hook/ps_bestsellers.tpl
+++ b/views/templates/hook/ps_bestsellers.tpl
@@ -29,5 +29,8 @@
       {include file="catalog/_partials/miniatures/product.tpl" product=$product}
     {/foreach}
   </div>
-  <a href="{$allBestSellers}">{l s='All best sellers' d='Modules.Bestsellers.Shop'}</a>
+
+  {if $displayBestSellers}
+    <a href="{$allBestSellers}">{l s='All best sellers' d='Modules.Bestsellers.Shop'}</a>
+  {/if}
 </section>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When you disable the best sellers page, the link on homepage will give you a 404 error.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| How to test?  | See that the link is removed when you disable the related option.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
