### PR TITLE
Remove random order

### DIFF
--- a/ps_bestsellers.php
+++ b/ps_bestsellers.php
@@ -213,22 +213,20 @@ class Ps_BestSellers extends Module implements WidgetInterface
             return false;
         }
 
+        // We will use the default core search provider to get the products
         $searchProvider = new BestSalesProductSearchProvider(
             $this->context->getTranslator()
         );
 
         $context = new ProductSearchContext($this->context);
 
+        // Build the search query
         $query = new ProductSearchQuery();
-
-        $nProducts = (int) Configuration::get('PS_BLOCK_BESTSELLERS_TO_DISPLAY');
-
         $query
-            ->setResultsPerPage($nProducts)
+            ->setResultsPerPage((int) Configuration::get('PS_BLOCK_BESTSELLERS_TO_DISPLAY'))
             ->setPage(1)
+            ->setSortOrder(new SortOrder('product', 'sales', 'desc'))
         ;
-
-        $query->setSortOrder(SortOrder::random());
 
         $result = $searchProvider->runQuery(
             $context,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This module uses core `BestSalesProductSearchProvider` to get the products. When building the query, it sets a `random` product order to the query, but this `SortOrder` is not supported by `ProductSale::getBestSales` function `BestSalesProductSearchProvider` is calling. For that reason, [there is a hardcore override in that provider](https://github.com/PrestaShop/PrestaShop/blob/1cebdca38e0112cc8d3dd7f5a390932e2c864ead/src/Adapter/BestSales/BestSalesProductSearchProvider.php#L66) - kind of a hackjob, that changes `SortOrder` to `sales`. We can remove that override in the core sometimes in the future, now we would break older versions of this module, for now, I am improving it at least in https://github.com/PrestaShop/PrestaShop/pull/31074,
| Type?         | refacto
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | See that best sales are still displayed on homepage and their order didn't change.
