### PR TITLE
Assemble products in bulk to save performance

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v2.0.0
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
@@ -70,14 +70,14 @@ jobs:
 
       # Add vendor folder in cache to make next builds faster
       - name: Cache vendor folder
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: vendor
           key: php-${{ hashFiles('composer.lock') }}
 
       # Add composer local folder in cache to make next builds faster
       - name: Cache composer folder
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache
           key: php-composer-cache

--- a/ps_bestsellers.php
+++ b/ps_bestsellers.php
@@ -258,12 +258,19 @@ class Ps_BestSellers extends Module implements WidgetInterface
             );
         }
 
+        // Now, we can present the products for the template.
         $products_for_template = [];
+        $rawProducts = $result->getProducts();
 
-        foreach ($result->getProducts() as $rawProduct) {
+        // Assemble & present in bulk or separately, depending on core version
+        $assembleInBulk = method_exists($assembler, 'assembleProducts');
+        if ($assembleInBulk) {
+            $rawProducts = $assembler->assembleProducts($rawProducts);
+        }
+        foreach ($rawProducts as $rawProduct) {
             $products_for_template[] = $presenter->present(
                 $presentationSettings,
-                $assembler->assembleProduct($rawProduct),
+                ($assembleInBulk ? $rawProduct : $assembler->assembleProduct($rawProduct)),
                 $this->context->language
             );
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Uses `assembleProducts` method added in 9.0 (https://github.com/PrestaShop/PrestaShop/pull/37399) for getting product data if it exists. This makes it load the data in just one query instead of n products.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Test that the module works correctly

### Related simmilar PRs:
https://github.com/PrestaShop/ps_newproducts/pull/29
https://github.com/PrestaShop/ps_specials/pull/19
https://github.com/PrestaShop/ps_bestsellers/pull/36
https://github.com/PrestaShop/ps_categoryproducts/pull/42
https://github.com/PrestaShop/ps_crossselling/pull/47
https://github.com/PrestaShop/ps_featuredproducts/pull/59
https://github.com/PrestaShop/ps_viewedproduct/pull/38